### PR TITLE
Adding a controls to kernel updates

### DIFF
--- a/tasks/rh6.yml
+++ b/tasks/rh6.yml
@@ -3,6 +3,7 @@
     name=kernel
     state=latest
   register: kernel
+  when: update_kernel|bool
 
 - name: "Restart machine"
   shell: |


### PR DESCRIPTION
Adding a control to allow ansible to be run multiple times without
causeing a reboot. This way running containers don't get knocked over
and production systems aren't restarted.
